### PR TITLE
Rtklib 2.4.3

### DIFF
--- a/app/rtkrcv/rtkrcv.c
+++ b/app/rtkrcv/rtkrcv.c
@@ -241,14 +241,6 @@ static opt_t rcvopts[]={
     
     {"",0,NULL,""}
 };
-/* keyboard interrupt handler ------------------------------------------------*/
-static void sigint(int sig)
-{
-    trace(3,"sigint: sig=%d\n",sig);
-    
-    intflg|=1;
-    signal(sig,sigint); /* reset signal handler */
-}
 /* external stop signal ------------------------------------------------------*/
 static void sigshut(int sig)
 {
@@ -1765,7 +1757,7 @@ int main(int argc, char **argv)
     /* start rtk server */
     if (start&&!startsvr(&vt)) return -1;
     
-    signal(SIGINT, sigint);     /* keyboard interrupt */
+    signal(SIGINT, sigshut);     /* keyboard interrupt */
     signal(SIGTERM,sigshut);    /* external shutdown signal */
     signal(SIGUSR2,sigshut);
     signal(SIGHUP ,SIG_IGN);

--- a/app/rtkrcv/rtkrcv.c
+++ b/app/rtkrcv/rtkrcv.c
@@ -1757,7 +1757,7 @@ int main(int argc, char **argv)
     /* start rtk server */
     if (start&&!startsvr(&vt)) return -1;
     
-    signal(SIGINT, sigshut);     /* keyboard interrupt */
+    signal(SIGINT ,sigshut);    /* keyboard interrupt */
     signal(SIGTERM,sigshut);    /* external shutdown signal */
     signal(SIGUSR2,sigshut);
     signal(SIGHUP ,SIG_IGN);


### PR DESCRIPTION
Hi Andrew,

I want to use your fork of RTKLIB to work with our gazebo simulator environment in ROS. However, there was one small problem with rtkrcv application that I didn't like: that it wouldn't seem to exit completely on keyboard interrupt command and continued to spin in the background and not release the terminal.

I browsed through the latest official RTKLIB code and found that they made a small change to rtkrcv to fix this. I integrated just this small change into your code and that seemed to do the trick.
